### PR TITLE
Fix/kuha-tnx organization filter

### DIFF
--- a/docs/backends.js
+++ b/docs/backends.js
@@ -127,17 +127,21 @@ var travisBackend = function(settings, resultCallback) {
    var parseBuilds = function(repos) {
       var responses = []
       repos.forEach(function(r) {
-         travisRequest(settings.url + '/' + r.name + '/builds', function(data) {
-            var reponame = r.name.split('/')[1]
-            var builds = data.builds.map(translateBuild(reponame, data.commits))
-            responses.push(builds)
-            if (responses.length === repos.length) {
-               var result = responses.reduce(function(acc, item) {
-                  return item.length > 0 ? acc.concat(item) : acc
-               }, [])
-               resultCallback(undefined, result)
-            }
-         })
+         // NOTE: Temporary hack to only get kuha-tnx repositories
+         var organizationName = r.name.split('/')[0];
+         if (organizationName === "kuha-tnx") {
+            travisRequest(settings.url + '/' + r.name + '/builds', function(data) {
+               var reponame = r.name.split('/')[1]
+               var builds = data.builds.map(translateBuild(reponame, data.commits))
+               responses.push(builds)
+               if (responses.length === repos.length) {
+                  var result = responses.reduce(function(acc, item) {
+                     return item.length > 0 ? acc.concat(item) : acc
+                  }, [])
+                  resultCallback(undefined, result)
+               }
+            })
+         }
       })
    }
 


### PR DESCRIPTION
# Reason

Travis API is broken. We don't know when it will be fixed, so why not do a temporary code change to show only our repositories?

# Implementation

Split the repo name and extract `kuha-tnx` from the property. Use that to get the right builds.

# Verification

Verified locally by running `index.html`.