### PR TITLE
added owner name filtering for Travis

### DIFF
--- a/docs/backends.js
+++ b/docs/backends.js
@@ -43,21 +43,26 @@ function backendOptions() {
       'circle': {
          name: 'Circle CI',
          url: 'https://circleci.com/api/v1/projects',
+         supportsOwnernameFiltering: false,
          token: undefined
       },
       'travis': {
          name: 'Travis CI',
          url: 'https://api.travis-ci.com/repos',
+         supportsOwnernameFiltering: true,
+         ownername: '',
          token: undefined
       },
       'jenkins': {
          name: 'Jenkins CI',
          url: undefined,
+         supportsOwnernameFiltering: false,
          token: undefined
       },
       'cloudwatch': {
          name: 'AWS CloudWatch',
          url: 'https://monitoring.eu-west-1.amazonaws.com/',
+         supportsOwnernameFiltering: false,
          token: undefined
       }
    }
@@ -141,7 +146,8 @@ var travisBackend = function(settings, resultCallback) {
       })
    }
 
-   travisRequest(settings.url, function(data) {
+   var reposUrl = settings.url + (settings.ownername ? '?owner_name=' + settings.ownername : '');
+   travisRequest(reposUrl, function(data) {
       parseBuilds(data.repos.map(function(repo) {return {id: repo.id, name: repo.slug}}))
    })
 }

--- a/docs/backends.js
+++ b/docs/backends.js
@@ -43,26 +43,23 @@ function backendOptions() {
       'circle': {
          name: 'Circle CI',
          url: 'https://circleci.com/api/v1/projects',
-         supportsOwnernameFiltering: false,
          token: undefined
       },
       'travis': {
          name: 'Travis CI',
          url: 'https://api.travis-ci.com/repos',
-         supportsOwnernameFiltering: true,
+         ownernameFiltering: true,
          ownername: '',
          token: undefined
       },
       'jenkins': {
          name: 'Jenkins CI',
          url: undefined,
-         supportsOwnernameFiltering: false,
          token: undefined
       },
       'cloudwatch': {
          name: 'AWS CloudWatch',
          url: 'https://monitoring.eu-west-1.amazonaws.com/',
-         supportsOwnernameFiltering: false,
          token: undefined
       }
    }

--- a/docs/index.html
+++ b/docs/index.html
@@ -80,6 +80,10 @@
     text-align: center;
   }
 
+  #ownername {
+    display: none;
+  }
+
   .settings-form {
     display: none;
     align-items: center;
@@ -141,6 +145,7 @@
     <h1>Configure API endpoint</h1>
     <select id="mode"></select>
     <input type="text" id="serverurl" placeholder="API base URL" autofocus></input>
+    <input type="text" id="ownername" placeholder="Owner name filter"></input>
     <input type="password" id="apitoken" placeholder="API token"></input>
     <input type="submit" value="Begin" id="submit"></input>
   </div>
@@ -232,6 +237,8 @@
       var opt = opts[settings.mode]
       settings.url = opt.url || settings.url
       settings.token = opt.token || settings.token
+      settings.supportsOwnernameFiltering = opt.supportsOwnernameFiltering;
+      settings.ownername = opt.ownername || settings.ownername
       return settings
     }
 
@@ -249,6 +256,7 @@
       var modeSelect = document.getElementById('mode')
       var serverUrlInput = document.getElementById('serverurl')
       var apiTokenInput = document.getElementById('apitoken')
+      var ownernameInput = document.getElementById('ownername')
       var submit = document.getElementById('submit')
       settingsForm.style.display = 'block'
 
@@ -267,6 +275,8 @@
         settings = extendWithDefaults(settings)
         serverUrlInput.value = settings.url
         apiTokenInput.value = settings.token
+        ownernameInput.value = settings.ownername
+        ownernameInput.style.display = settings.supportsOwnernameFiltering ? 'block' : 'none'
       }
       setUISelections(settings.mode || defaults[_.keys(defaults)[0]].mode)
 
@@ -278,6 +288,7 @@
         settingsForm.style.display = 'none'
         settings.url = serverUrlInput.value
         settings.token = apiTokenInput.value
+        settings.ownername = ownernameInput.value
         start(settings)
       })
     }

--- a/docs/index.html
+++ b/docs/index.html
@@ -237,7 +237,7 @@
       var opt = opts[settings.mode]
       settings.url = opt.url || settings.url
       settings.token = opt.token || settings.token
-      settings.supportsOwnernameFiltering = opt.supportsOwnernameFiltering;
+      settings.ownernameFiltering = opt.ownernameFiltering;
       settings.ownername = opt.ownername || settings.ownername
       return settings
     }
@@ -276,7 +276,7 @@
         serverUrlInput.value = settings.url
         apiTokenInput.value = settings.token
         ownernameInput.value = settings.ownername
-        ownernameInput.style.display = settings.supportsOwnernameFiltering ? 'block' : 'none'
+        ownernameInput.style.display = settings.ownernameFiltering ? 'block' : 'none'
       }
       setUISelections(settings.mode || defaults[_.keys(defaults)[0]].mode)
 


### PR DESCRIPTION
# Reason

Travis API has started to return a bunch of public repositories in addition to our own repos. The API supports filtering by repo owner, so that can be used to receive only our repos.

# Implementation

The radiator now supports parameter `ownername`. It can be given in URL like this: https://kuha-tnx.github.io/radiator-view/docs/index.html?mode=travis&branch=master&token=TOKEN&ownername=kuha-tnx

Additionally added the new owner filter as a form field to UI, if radiator is started without query parameters. Currently this is shown only if selected mode is Travis. For other CI options the form field is not shown. This is configurable separately for each CI mode.

# Verification

Ran locally index.html with query parameters & by using the UI.