### PR TITLE
Concourse support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-   - "7"
-
-install: true
-
-script: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+   - "7"
+
+install: true
+
+script: true

--- a/docs/backends.js
+++ b/docs/backends.js
@@ -66,7 +66,7 @@ function backendOptions() {
       },
       'concourse': {
          name: 'Concourse',
-         url: 'https://concourse.dev.kuha.io/',
+         url: 'https://ci.dev.kuha.io/',
          token: null
       }
    }

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,7 +34,7 @@
   li:first-child {
     border-top: 0;
   }
-  .success, .fixed, .passed {
+  .success, .fixed, .passed, .succeeded {
     background-color: #42c88a;
   }
   .failed, .infrastructure_fail, .timedout, .errored  {


### PR DESCRIPTION
# Reason
Possibility to use Concourse as a datasource for radiator-view.

# Implementation
Added concourse backend that maps concourse /api/v1/builds to radiator-view builds. Concourse does not provide all the data used in radiator-view. An ad-hoc mapping was done.

# Verification
Tested locally against https://ci.dev.kuha.io with appropriate api key.
